### PR TITLE
Added scroll in view option to scroll container as you keydown

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Use CSS to style the active descendant however you wish:
 
 In this example the focusable element is an ancestor of the list items and therefore the "descendant" relationship can be automatically determined from the DOM hierarchy. This is typical of a standalone listbox or grid widget.
 
-**NOTE**: this module does not add any ARIA roles; only states and properties.  
+**NOTE**: this module does not add any ARIA roles; only states and properties.
 
 Starting markup:
 
@@ -177,6 +177,7 @@ Use CSS to style the active descendant however you wish:
 * `autoInit`: specify an integer or -1 for initial index (default: 0) (see [`makeup-navigation-emitter`](https://github.com/makeup-js/makeup-navigation-emitter#options))
 * `autoReset`: specify an integer or -1 for index position when focus exits widget (default: null) (see [`makeup-navigation-emitter`](https://github.com/makeup-js/makeup-navigation-emitter#options))
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
+* `scrollInView` : Specify true to scroll the container with all the elements so that they are always in view as you keydown (default: false)
 
 ## Custom Events
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ var defaultOptions = {
   activeDescendantClassName: 'active-descendant',
   autoInit: -1,
   autoReset: -1,
-  axis: 'both'
+  axis: 'both',
+  autoScroll: false
 };
 
 function onModelMutation() {
@@ -61,6 +62,11 @@ function onModelChange(e) {
     toItem.classList.add(this._options.activeDescendantClassName);
 
     this._focusEl.setAttribute('aria-activedescendant', toItem.id);
+
+    if (this._config.autoScroll && this._containerEl) {
+      this._containerEl.scrollTop = toItem.offsetTop - this._containerEl.offsetHeight / 2;
+
+    }
   }
 
   this._el.dispatchEvent(new CustomEvent('activeDescendantChange', {


### PR DESCRIPTION
Added a new option that when set will cause the container to scroll with the selected item. It will position itself approximately halfway.
If scrollTop is negative then it defaults to 0, if it's greater than scroll amount it will scroll to end. 
This is specifically for this issue. https://github.com/eBay/ebayui-core/issues/1033

(Looks like it also removed an extra whitespace in readme)